### PR TITLE
Add pattern learner and template matching

### DIFF
--- a/Sources/WorkoutCounter/Models.swift
+++ b/Sources/WorkoutCounter/Models.swift
@@ -57,3 +57,11 @@ public final class SessionManager {
         analytics.registerRepetition(start: startOffset, end: endOffset)
     }
 }
+
+/// Describes key metrics extracted from a motion sequence
+public struct MovementFeatures {
+    public let jointVelocities: [String: Float]
+    public let jointAngles: [String: Float]
+    public let movementIntensity: Float
+    public let symmetry: Float
+}

--- a/Sources/WorkoutCounter/PatternLearner.swift
+++ b/Sources/WorkoutCounter/PatternLearner.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Represents a learned template for a particular exercise
+public struct ExercisePattern {
+    public let jointVelocities: [String: Float]
+    public let jointAngles: [String: Float]
+    public let movementIntensity: Float
+    public let symmetry: Float
+}
+
+/// Naïve pattern learner that averages features across examples
+public final class PatternLearner {
+    private var positive: [MovementFeatures] = []
+    private var negative: [MovementFeatures] = []
+
+    public init() {}
+
+    public func startLearningSession() {
+        positive.removeAll()
+        negative.removeAll()
+    }
+
+    public func recordPositiveExample(poses: [PoseSample]) {
+        positive.append(Self.extractFeatures(from: poses))
+    }
+
+    public func recordNegativeExample(poses: [PoseSample]) {
+        negative.append(Self.extractFeatures(from: poses))
+    }
+
+    public func generatePattern() -> ExercisePattern {
+        let count = Float(positive.count)
+        guard count > 0 else {
+            return ExercisePattern(jointVelocities: [:], jointAngles: [:], movementIntensity: 0, symmetry: 0)
+        }
+        var velocities: [String: Float] = [:]
+        var angles: [String: Float] = [:]
+        var intensity: Float = 0
+        var symmetry: Float = 0
+        for f in positive {
+            for (k,v) in f.jointVelocities { velocities[k, default: 0] += v }
+            for (k,v) in f.jointAngles { angles[k, default: 0] += v }
+            intensity += f.movementIntensity
+            symmetry += f.symmetry
+        }
+        for k in velocities.keys { velocities[k]! /= count }
+        for k in angles.keys { angles[k]! /= count }
+        return ExercisePattern(
+            jointVelocities: velocities,
+            jointAngles: angles,
+            movementIntensity: intensity / count,
+            symmetry: symmetry / count
+        )
+    }
+
+    // MARK: - Feature Extraction
+    static func extractFeatures(from poses: [PoseSample]) -> MovementFeatures {
+        guard !poses.isEmpty else {
+            return MovementFeatures(jointVelocities: [:], jointAngles: [:], movementIntensity: 0, symmetry: 0)
+        }
+        var velocities: [Float] = []
+        for i in 1..<poses.count {
+            let dt = poses[i].time - poses[i-1].time
+            if dt > 0 {
+                let v = Float((poses[i].metric - poses[i-1].metric)/dt)
+                velocities.append(abs(v))
+            }
+        }
+        let avgVel = velocities.reduce(0, +) / Float(max(velocities.count,1))
+        let metrics = poses.map { Float($0.metric) }
+        let maxMetric = metrics.max() ?? 0
+        let minMetric = metrics.min() ?? 0
+        let intensity = maxMetric - minMetric
+        return MovementFeatures(
+            jointVelocities: ["metric": avgVel],
+            jointAngles: ["metric": 0],
+            movementIntensity: intensity,
+            symmetry: 1
+        )
+    }
+}

--- a/Sources/WorkoutCounter/RepetitionDetector.swift
+++ b/Sources/WorkoutCounter/RepetitionDetector.swift
@@ -37,3 +37,20 @@ public final class RepetitionDetector {
         return nil
     }
 }
+
+/// Compares extracted features to a learned exercise pattern. Returns a score 0...1.
+public func matchAgainstPattern(_ features: MovementFeatures, pattern: ExercisePattern) -> Float {
+    var score: Float = 0
+    // compare movement intensity
+    let diff = abs(features.movementIntensity - pattern.movementIntensity)
+    let intensityScore = max(0, 1 - diff)
+    score += intensityScore
+    // compare average velocity if available
+    if let fVel = features.jointVelocities["metric"], let pVel = pattern.jointVelocities["metric"] {
+        let velDiff = abs(fVel - pVel)
+        score += max(0, 1 - velDiff)
+    }
+    // symmetry currently constant
+    score += 1 - abs(features.symmetry - pattern.symmetry)
+    return score / 3
+}

--- a/Tests/WorkoutCounterTests/RepetitionTests.swift
+++ b/Tests/WorkoutCounterTests/RepetitionTests.swift
@@ -31,3 +31,18 @@ func sessionAnalytics() async throws {
     #expect(manager.sessions[0].repetitions.count == 2)
     #expect(!manager.sessionAnalytics.restDurations.isEmpty)
 }
+
+@Test
+func patternLearningAndMatching() async throws {
+    let learner = PatternLearner()
+    learner.startLearningSession()
+    for _ in 0..<5 {
+        let rep = generateMockPoseData(repetitions: 1)
+        learner.recordPositiveExample(poses: rep)
+    }
+    let pattern = learner.generatePattern()
+    let newRep = generateMockPoseData(repetitions: 1)
+    let features = PatternLearner.extractFeatures(from: newRep)
+    let score = matchAgainstPattern(features, pattern: pattern)
+    #expect(score > 0.5)
+}


### PR DESCRIPTION
## Summary
- add `MovementFeatures` to capture motion metrics
- implement `PatternLearner` for averaging features
- add template matching helper in `RepetitionDetector`
- add test covering learning and matching

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_684028cc8a74833280ecb49860a6ebdf